### PR TITLE
Loading Indicator Bug

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,17 @@
 import { UserProvider } from "./context/User.context";
 import { NavigationProvider } from "./context/Navigation.context";
 import AppRouter from "./AppRouter";
-import React from "react";
-import ReactDOM from "react-dom/client";
 import "./index.globals.css";
-import { ClerkProvider } from "@clerk/clerk-react";
-import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import { ClassesProvider } from "./context/Classes.context";
+import { InvitesProvider } from "./context/Invites.context";
+import { TeachersProvider } from "./context/Teachers.context";
+import { VolunteersProvider } from "./context/Volunteers.context";
+import { AdminsProvider } from "./context/Admins.context";
+import { ToastContainer } from "react-toastify";
+import { ClerkProvider } from "@clerk/clerk-react";
+import ReactDOM from "react-dom/client";
+import React from "react";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
@@ -22,21 +27,31 @@ root.render(
   <React.StrictMode>
     <UserProvider>
       <ClerkProvider publishableKey={clerkPubKey}>
-        <NavigationProvider>
-          <ToastContainer
-            position="bottom-center"
-            autoClose={4000}
-            hideProgressBar={false}
-            newestOnTop={false}
-            closeOnClick
-            rtl={false}
-            pauseOnFocusLoss
-            draggable
-            pauseOnHover
-            theme="light"
-          />
-          <AppRouter />
-        </NavigationProvider>
+        <AdminsProvider>
+          <InvitesProvider>
+            <TeachersProvider>
+              <ClassesProvider>
+                <VolunteersProvider>
+                  <NavigationProvider>
+                    <ToastContainer
+                      position="bottom-center"
+                      autoClose={4000}
+                      hideProgressBar={false}
+                      newestOnTop={false}
+                      closeOnClick
+                      rtl={false}
+                      pauseOnFocusLoss
+                      draggable
+                      pauseOnHover
+                      theme="light"
+                    />
+                    <AppRouter />
+                  </NavigationProvider>
+                </VolunteersProvider>
+              </ClassesProvider>
+            </TeachersProvider>
+          </InvitesProvider>
+        </AdminsProvider>
       </ClerkProvider>
     </UserProvider>
   </React.StrictMode>,

--- a/src/layout/App/App.tsx
+++ b/src/layout/App/App.tsx
@@ -14,7 +14,7 @@ import { Navigate, Outlet, useNavigate } from "react-router";
 import { useUser } from "@clerk/clerk-react";
 
 const App = () => {
-  const { setCurrentUser } = useUserContext();
+  const { currentUser, setCurrentUser } = useUserContext();
   const { user } = useUser();
   const navigate = useNavigate();
 
@@ -56,7 +56,7 @@ const App = () => {
     }
   }, [userData]);
 
-  if (userLoading || !userData) {
+  if (userLoading || !currentUser) {
     return <FullPageLoadingIndicator />;
   }
 
@@ -71,10 +71,10 @@ const App = () => {
       </div>
       <div className={styles["app-main-content"]}>
         <div className={styles["app-main-content-inner-container"]}>
-          {userData.approvalStatus === ApprovalStatus.APPROVED ? (
+          {currentUser.approvalStatus === ApprovalStatus.APPROVED ? (
             <Outlet />
           ) : (
-            <NotApprovedDisplay status={userData.approvalStatus} />
+            <NotApprovedDisplay status={currentUser.approvalStatus} />
           )}
         </div>
       </div>

--- a/src/layout/App/App.tsx
+++ b/src/layout/App/App.tsx
@@ -15,8 +15,9 @@ import { useUser } from "@clerk/clerk-react";
 
 const App = () => {
   const { currentUser, setCurrentUser } = useUserContext();
-  const { user } = useUser();
+  const { user, isLoaded } = useUser();
   const navigate = useNavigate();
+  // const location = useLocation();
 
   // request to create the user
   const {
@@ -24,13 +25,7 @@ const App = () => {
     error: errorUser,
     loading: userLoading,
     makeRequest: makeUserRequest,
-  } = useCustomFetch<UserType>(
-    `/accounts?accountEmail=${
-      user?.primaryEmailAddress?.emailAddress ||
-      getValueFromLocalStorage("accountEmail")
-    }`,
-    RequestMethods.GET_WAIT,
-  );
+  } = useCustomFetch<UserType>(`/accounts`, RequestMethods.GET_WAIT);
 
   useEffect(() => {
     if (
@@ -40,8 +35,20 @@ const App = () => {
       navigate("/sign-in");
     }
 
-    makeUserRequest();
-  }, []);
+    if (isLoaded && !currentUser) {
+      const email =
+        user?.primaryEmailAddress?.emailAddress ||
+        getValueFromLocalStorage("accountEmail") ||
+        "";
+
+      const role =
+        user?.publicMetadata.role ||
+        getValueFromLocalStorage("accountRole") ||
+        "";
+
+      makeUserRequest(undefined, `?accountEmail=${email}&role=${role}`);
+    }
+  }, [isLoaded]);
 
   useEffect(() => {
     if (userData) {

--- a/src/modals/SignUpModal/SignUpModal.tsx
+++ b/src/modals/SignUpModal/SignUpModal.tsx
@@ -12,7 +12,7 @@ import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useAuth, useSignUp } from "@clerk/clerk-react";
 import { useEffect, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { MoonLoader } from "react-spinners";
 import type { Admin, UserType } from "../../interfaces/User.interface";
 import type { SignUpCodeInput, SignUpInput } from "./SignUpModal.definitions";
@@ -22,7 +22,6 @@ const SignUpModal = () => {
   // hooks clerk and react-router-dom
   const { isLoaded, signUp, setActive } = useSignUp();
   const { signOut } = useAuth();
-  const navigate = useNavigate();
   const { setCurrentUser } = useUserContext();
 
   // get the invite id from the url
@@ -91,12 +90,8 @@ const SignUpModal = () => {
   }, [inviteData]);
 
   useEffect(() => {
-    console.log(userData, errorUser, userLoading);
-    if (userData && !errorUser && !userLoading) {
+    if (userData && !errorUser && !userLoading && isLoaded) {
       setCurrentUser(userData);
-      setValueToLocalStorage("accountEmail", userData.email);
-      setValueToLocalStorage("accountRole", userData.role);
-      navigate("/");
     }
 
     // if there is an error, sign out (might want to change this later)
@@ -179,6 +174,9 @@ const SignUpModal = () => {
     if (completeSignUp.status === "complete") {
       // set the user as active in clerk
       await setActive({ session: completeSignUp.createdSessionId });
+
+      setValueToLocalStorage("accountEmail", signUp.emailAddress);
+      setValueToLocalStorage("accountRole", inviteData?.role);
 
       // call the backend to create the user
       await makeUserRequest({


### PR DESCRIPTION
So what was the issue here?

It turns out, Clerk is slightly slower than the process of events that we have for sign up. Since we get the role from the decoded clerk token, we need clerk to recognize that we are logged in BEFORE we send the request to get the user right after we sign up. Unfortunately, the router was moving faster than clerk, so it was redirecting to the dashboard and making the request with an invalid token before clerk had time to swap the token out with the logged in one. Therefore the backend was looking at a token that was missing the "role" field which caused it to send back a 400.

To fix this, I simplified the routing by splitting up the app into two separate routers, one protected and one not protected. While I was at it, I globalized the contexts as well so it looks nicer (see `index.tsx` for that change). Also, the backend endpoint for the retrieval accounts takes a role as a query parameter instead of from the token. I did some manual security testing on this but I want to make sure that authenticated users can't just grab anyone's info. I haven't been able to do that yet but I will look more into that later.